### PR TITLE
feat: Add Traefik integration and improve seed script

### DIFF
--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -6,6 +6,22 @@ const prisma = new PrismaClient();
 async function main() {
   console.log('🌱 Iniciando seed do banco de dados...');
 
+  // Verificar se já existem dados
+  const existingUsers = await prisma.user.count();
+  const existingCollections = await prisma.collectionItem.count();
+
+  if (existingUsers > 0 || existingCollections > 0) {
+    console.log('ℹ️  Banco de dados já contém dados.');
+    console.log(`   Usuários: ${existingUsers}`);
+    console.log(`   Coletas: ${existingCollections}`);
+    console.log('⏭️  Pulando seed para evitar duplicação.');
+    console.log('💡 Dica: Para recriar os dados, execute:');
+    console.log('   docker exec recicla-backend npx prisma migrate reset');
+    return;
+  }
+
+  console.log('📝 Banco de dados vazio. Criando dados iniciais...');
+
   // Limpar dados existentes (opcional - comentar em produção)
   // await prisma.pointsTransaction.deleteMany();
   // await prisma.trackingEvent.deleteMany();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,19 @@ services:
         condition: service_healthy
     networks:
       - recicla-network
+      - traefik
     volumes:
       - ./uploads:/app/uploads
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik"
+      - "traefik.http.routers.recicla-backend.rule=Host(`appcoleta.polygonconsulting.com.br`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.recicla-backend.entrypoints=websecure"
+      - "traefik.http.routers.recicla-backend.tls=true"
+      - "traefik.http.routers.recicla-backend.tls.certresolver=letsencrypt"
+      - "traefik.http.middlewares.recicla-backend-stripprefix.stripprefix.prefixes=/api"
+      - "traefik.http.routers.recicla-backend.middlewares=recicla-backend-stripprefix"
+      - "traefik.http.services.recicla-backend.loadbalancer.server.port=3000"
 
   # Frontend (React + Nginx)
   frontend:
@@ -50,21 +61,32 @@ services:
       dockerfile: Dockerfile
     container_name: recicla-frontend
     restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
     environment:
       - REACT_APP_API_URL=https://appcoleta.polygonconsulting.com.br/api
     depends_on:
       - backend
     networks:
       - recicla-network
-    volumes:
-      - ./ssl:/etc/nginx/ssl:ro
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik"
+      - "traefik.http.routers.recicla-frontend.rule=Host(`appcoleta.polygonconsulting.com.br`)"
+      - "traefik.http.routers.recicla-frontend.entrypoints=web"
+      - "traefik.http.routers.recicla-frontend.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.permanent=true"
+      - "traefik.http.routers.recicla-frontend-secure.rule=Host(`appcoleta.polygonconsulting.com.br`)"
+      - "traefik.http.routers.recicla-frontend-secure.entrypoints=websecure"
+      - "traefik.http.routers.recicla-frontend-secure.tls=true"
+      - "traefik.http.routers.recicla-frontend-secure.tls.certresolver=letsencrypt"
+      - "traefik.http.services.recicla-frontend.loadbalancer.server.port=80"
 
 networks:
   recicla-network:
     driver: bridge
+  traefik:
+    external: true
 
 volumes:
   postgres_data:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,75 +1,15 @@
-# Redirecionar HTTP para HTTPS
 server {
     listen 80;
-    server_name appcoleta.polygonconsulting.com.br;
-    return 301 https://$server_name$request_uri;
-}
-
-# Configuração HTTPS
-server {
-    listen 443 ssl http2;
-    server_name appcoleta.polygonconsulting.com.br;
+    server_name _;
     root /usr/share/nginx/html;
     index index.html;
 
-    # Configurações SSL
-    ssl_certificate /etc/nginx/ssl/appcoleta.polygonconsulting.com.br.crt;
-    ssl_certificate_key /etc/nginx/ssl/appcoleta.polygonconsulting.com.br.key;
+    # Gzip
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
     
-    # Configurações de segurança SSL
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
-    ssl_prefer_server_ciphers off;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 10m;
-    
-    # Headers de segurança
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options DENY always;
-    add_header X-Content-Type-Options nosniff always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
-    # Proxy para API backend
-    location /api/ {
-        proxy_pass http://backend:3000/;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
-        proxy_read_timeout 86400;
-    }
-
-    # Configuração para SPA (Single Page Application)
+    # SPA routing
     location / {
         try_files $uri $uri/ /index.html;
     }
-
-    # Cache para arquivos estáticos
-    location /static/ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    # Cache para assets
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    # Desabilitar cache para index.html
-    location = /index.html {
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-    }
-
-    # Compressão gzip
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 1024;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json application/javascript;
 }
-


### PR DESCRIPTION
- Remove direct port mapping (80/443) from frontend to avoid conflicts with Traefik
- Add Traefik labels for automatic routing and SSL termination
- Configure backend API routing through /api path with prefix stripping
- Add external traefik network configuration
- Simplify nginx.conf to serve only on port 80 (SSL handled by Traefik)
- Improve seed script to check for existing data before populating
- Add informative messages when skipping seed due to existing data
- Provide guidance for resetting database if needed